### PR TITLE
updated logic to use a base64 encoded private key for the google api …

### DIFF
--- a/mhlc-content-api/package.json
+++ b/mhlc-content-api/package.json
@@ -5,6 +5,7 @@
   "main": "index.js",
   "scripts": {
     "start": "node ./src/index.js",
+    "b64-google-private-key": "node ./src/b64GooglePrivateKey.js",
     "refresh-mock-content": "node ./src/refreshMockContent.js"
   },
   "author": "MHLC Technology Team",

--- a/mhlc-content-api/src/analyticsService.js
+++ b/mhlc-content-api/src/analyticsService.js
@@ -15,11 +15,13 @@ let initialized = false;
 async function initialize() {
     if (process.env.GOOGLE_APIS_ANALYTICS_ENABLED === 'true') {
         try {
+            const privateKeyB64 = process.env.GOOGLE_APIS_ANALYTICS_PRIVATE_KEY_B64;
+            const privateKey = Buffer.from(privateKeyB64, 'base64').toString();
             const credentials = {
                 type: 'service_account',
                 project_id: process.env.GOOGLE_APIS_ANALYTICS_PROJECT_ID,
                 private_key_id: process.env.GOOGLE_APIS_ANALYTICS_PRIVATE_KEY_ID,
-                private_key: process.env.GOOGLE_APIS_ANALYTICS_PRIVATE_KEY,
+                private_key: privateKey,
                 client_email: process.env.GOOGLE_APIS_ANALYTICS_CLIENT_EMAIL,
                 client_id: process.env.GOOGLE_APIS_ANALYTICS_CLIENT_ID,
                 auth_uri: 'https://accounts.google.com/o/oauth2/auth',

--- a/mhlc-content-api/src/b64GooglePrivateKey.js
+++ b/mhlc-content-api/src/b64GooglePrivateKey.js
@@ -1,0 +1,7 @@
+require('dotenv').config();
+
+const key = process.env.GOOGLE_APIS_ANALYTICS_PRIVATE_KEY;
+
+const b64Key = Buffer.from(key).toString('base64');
+
+console.log(b64Key);

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "description": "GitHub project for the website of Mt. Horeb Lutheran Church, Chapin, SC - <https://mthoreb.net/>",
   "main": "index.js",
   "scripts": {
+    "b64-google-private-key": "npm run b64-google-private-key -w mhlc-content-api",
     "build:ui": "npm run build -w mhlc-ui",
     "dev:ui": "npm run dev -w mhlc-ui",
     "refresh-mock-content": "npm run refresh-mock-content -w mhlc-content-api",


### PR DESCRIPTION
Description: updated to use a base64 encoded version of the google api private cert so as to avoid newline character escaping issues.  This addresses issue #74 