### PR TITLE
Issue/fixing missing news types

### DIFF
--- a/mhlc-content-api/src/services/contentService.js
+++ b/mhlc-content-api/src/services/contentService.js
@@ -175,7 +175,7 @@ async function getNewsEntries(page) {
             description: item.fields.description,
             type: item.fields.type ? item.fields.type.map(type => ({
                 id: type.sys.id,
-                type: type.fields?.type
+                type: type.fields?.type ?? 'General'
             })) : [],
             image: item.fields.image ? item.fields.image.fields.file : null,
             attachments: item.fields.attachments ? item.fields.attachments.map((attachment) => ({

--- a/mhlc-content-api/src/services/contentService.js
+++ b/mhlc-content-api/src/services/contentService.js
@@ -175,7 +175,7 @@ async function getNewsEntries(page) {
             description: item.fields.description,
             type: item.fields.type ? item.fields.type.map(type => ({
                 id: type.sys.id,
-                type: type.fields.type
+                type: type.fields?.type
             })) : [],
             image: item.fields.image ? item.fields.image.fields.file : null,
             attachments: item.fields.attachments ? item.fields.attachments.map((attachment) => ({


### PR DESCRIPTION
Description: Fixing a bug where a news type content record was deleted and resulted in a lot of invalid news records with no type.  Not entirely sure how this happened - I thought contentful stopped you from deleting something if there were linked records, but regardless, there's a check and default/failsafe for this case now.